### PR TITLE
Updated mustache render method

### DIFF
--- a/lib/zen.response.coffee
+++ b/lib/zen.response.coffee
@@ -46,7 +46,7 @@ response =
     files = {}
     files[partial] = __mustache partial for partial in partials or []
     bindings.zen = global.ZEN
-    @html mustache.to_html(__mustache(file), bindings, files), code
+    @html mustache.render(__mustache(file), bindings, files), code
 
   # -- JSON responses ----------------------------------------------------------
   json: (data = {}, code, headers = {}) ->


### PR DESCRIPTION
According to the mustache code, `to_html` is a backwards compatibility method. https://github.com/janl/mustache.js/blob/master/mustache.js#L558

Updated to `render` method.
